### PR TITLE
feat: mostrar toda la informacion del perfil

### DIFF
--- a/frontend/src/components/ProfileInformation.jsx
+++ b/frontend/src/components/ProfileInformation.jsx
@@ -18,13 +18,218 @@ import {
   Value,
   Actions,
   TwoColumnRow,
+  Stack,
+  Group,
+  GroupTitle,
 } from './ProfileInformation.styles.jsx';
+import {
+  HABITOS_OPCIONES,
+  SISTEMAS_OPCIONES,
+  INSPECCION_OPCIONES,
+} from '../helpers/add/catalogos.js';
 
 // Valor presente: distinto de null/undefined y strings no vacíos
-const present = (v) => {
-  if (v == null) return false;
-  if (typeof v === 'string') return v.trim().length > 0;
+const present = (value) => {
+  if (value == null) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
   return true;
+};
+
+const toStr = (value) => (value == null ? '' : String(value));
+const toArr = (value) => (Array.isArray(value) ? value : []);
+
+const formatDate = (value) => {
+  const str = toStr(value).trim();
+  if (!str) return '';
+  const match = str.match(/\d{4}-\d{2}-\d{2}/);
+  return match ? match[0] : str;
+};
+
+const normalize = (text) =>
+  String(text ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+const findMatchingLabel = (options, needle, fallback) => {
+  const normalizedNeedle = normalize(needle);
+  const exact = options.find((opt) => normalize(opt) === normalizedNeedle);
+  if (exact) return exact;
+  const partial = options.find((opt) => normalize(opt).includes(normalizedNeedle));
+  return partial || fallback || needle;
+};
+
+const SISTEMA_FIELD_MAPPINGS = [
+  { needle: 'Sintomas generales', keys: ['sintomas_generales_desc', 'sintomas_generales'] },
+  { needle: 'Endocrino', keys: ['endocrino_desc', 'endocrino'] },
+  { needle: 'Organos de los sentidos', keys: ['organos_sentidos_desc', 'organos_sentidos'] },
+  { needle: 'Gastrointestinal', keys: ['gastrointestinal_desc', 'gastrointestinal'] },
+  { needle: 'Cardiopulmonar', keys: ['cardiopulmonar_desc', 'cardiopulmonar'] },
+  { needle: 'Genitourinario', keys: ['genitourinario_desc', 'genitourinario'] },
+  { needle: 'Genital femenino', keys: ['genital_femenino_desc', 'genital_femenino'] },
+  { needle: 'Sexualidad', keys: ['sexualidad_desc', 'sexualidad'] },
+  { needle: 'Dermatologico', keys: ['dermatologico_desc', 'dermatologico'] },
+  { needle: 'Neurologico', keys: ['neurologico_desc', 'neurologico'] },
+  { needle: 'Hematologico', keys: ['hematologico_desc', 'hematologico'] },
+  { needle: 'Reumatologico', keys: ['reumatologico_desc', 'reumatologico'] },
+  { needle: 'Psiquiatrico', keys: ['psiquiatrico_desc', 'psiquiatrico'] },
+  { needle: 'Medicamentos', keys: ['medicamentos_desc', 'medicamentos'] },
+];
+
+const parseDateValue = (value) => {
+  if (!value) return Number.NEGATIVE_INFINITY;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? Number.NEGATIVE_INFINITY : parsed;
+};
+
+const sortConsultasDesc = (entries = []) => {
+  const fallbackMap = new Map();
+  const orderMap = new Map();
+  entries.forEach((item, index) => {
+    const fallbackKey = `idx-${index}`;
+    fallbackMap.set(item, fallbackKey);
+    orderMap.set(item?.uid ?? fallbackKey, index);
+  });
+
+  return [...entries].sort((a, b) => {
+    const diff = parseDateValue(b?.fecha_consulta) - parseDateValue(a?.fecha_consulta);
+    if (diff !== 0) return diff;
+    const keyA = a?.uid ?? fallbackMap.get(a);
+    const keyB = b?.uid ?? fallbackMap.get(b);
+    const idxA = orderMap.get(keyA) ?? 0;
+    const idxB = orderMap.get(keyB) ?? 0;
+    return idxA - idxB;
+  });
+};
+
+const mapSistemasFromSource = (source = {}) => {
+  const direct = toArr(source?.interrogatorio_aparatos)
+    .map((item) => {
+      const nombre = toStr(item?.nombre);
+      const descripcion = toStr(item?.descripcion);
+      if (!present(nombre) && !present(descripcion)) return null;
+      return { nombre, descripcion };
+    })
+    .filter(Boolean);
+
+  if (direct.length > 0) return direct;
+
+  return SISTEMA_FIELD_MAPPINGS
+    .map(({ needle, keys }) => {
+      const label = findMatchingLabel(SISTEMAS_OPCIONES, needle, needle);
+      const descripcion = keys
+        .map((key) => toStr(source?.[key]).trim())
+        .find((value) => value.length > 0);
+      return descripcion ? { nombre: label, descripcion } : null;
+    })
+    .filter(Boolean);
+};
+
+const mapInspectionFromSource = (ef = {}) => {
+  const inspectionMappings = [
+    { needle: 'Cabeza', value: ef.cabeza },
+    { needle: 'Cuello', value: ef.cuello },
+    { needle: 'Torax', value: ef.torax },
+    { needle: 'Abdomen', value: ef.abdomen },
+    { needle: 'Genitales', value: ef.genitales },
+    { needle: 'Extremidades', value: ef.extremidades },
+  ];
+
+  return inspectionMappings
+    .map(({ needle, value }) => {
+      const descripcion = toStr(value).trim();
+      if (!descripcion) return null;
+      const nombre = findMatchingLabel(INSPECCION_OPCIONES, needle, needle);
+      return { nombre, descripcion };
+    })
+    .filter(Boolean);
+};
+
+const buildHabitos = (ap = {}) => {
+  const habitos = [];
+
+  if (present(ap.bebidas_por_dia) || present(ap.tiempo_activo_alc)) {
+    const label = findMatchingLabel(HABITOS_OPCIONES, 'Alcoholismo', HABITOS_OPCIONES[0] || 'Alcoholismo');
+    habitos.push({
+      titulo: label,
+      rows: [
+        { label: 'Bebidas por día', value: ap.bebidas_por_dia },
+        { label: 'Tiempo activo', value: ap.tiempo_activo_alc },
+      ],
+    });
+  }
+
+  if (present(ap.cigarrillos_por_dia) || present(ap.tiempo_activo_tab)) {
+    const label = findMatchingLabel(HABITOS_OPCIONES, 'Tabaquismo', HABITOS_OPCIONES[1] || 'Tabaquismo');
+    habitos.push({
+      titulo: label,
+      rows: [
+        { label: 'Cigarrillos por día', value: ap.cigarrillos_por_dia },
+        { label: 'Tiempo activo', value: ap.tiempo_activo_tab },
+      ],
+    });
+  }
+
+  if (present(ap.tipo_toxicomania) || present(ap.tiempo_activo_tox)) {
+    const label = findMatchingLabel(HABITOS_OPCIONES, 'Toxicomanias', HABITOS_OPCIONES[2] || 'Toxicomanias');
+    habitos.push({
+      titulo: label,
+      rows: [
+        { label: 'Tipo', value: ap.tipo_toxicomania },
+        { label: 'Tiempo activo', value: ap.tiempo_activo_tox },
+      ],
+    });
+  }
+
+  return habitos;
+};
+
+const buildConsultas = (data = {}) => {
+  const consRows = sortConsultasDesc(toArr(data.consultas));
+
+  const consultas = consRows
+    .map((row, idx) => {
+      const base = {
+        id: row?.uid || row?.id || `consulta-${idx}`,
+        fecha_consulta: formatDate(row?.fecha_consulta),
+        recordatorio: formatDate(row?.recordatorio),
+        padecimiento_actual: toStr(row?.padecimiento_actual),
+        diagnostico: toStr(row?.diagnostico),
+        tratamiento: toStr(row?.tratamiento),
+        notas: toStr(row?.notas),
+        interrogatorio: mapSistemasFromSource(row),
+      };
+      const hasData =
+        ['fecha_consulta', 'recordatorio', 'padecimiento_actual', 'diagnostico', 'tratamiento', 'notas']
+          .some((key) => present(base[key])) || present(base.interrogatorio);
+      return hasData ? base : null;
+    })
+    .filter(Boolean);
+
+  const legacyRows = toArr(data.padecimiento_actual_interrogatorio);
+  const dtRows = toArr(data.diagnostico_tratamiento);
+  const pronostico = toStr(dtRows[0]?.pronostico);
+
+  if (consultas.length === 0) {
+    const fallbackSource = { ...(legacyRows[0] || {}), ...(dtRows[0] || {}) };
+    const fallback = {
+      id: 'consulta-legacy',
+      fecha_consulta: formatDate(fallbackSource.fecha_consulta),
+      recordatorio: formatDate(fallbackSource.recordatorio),
+      padecimiento_actual: toStr(fallbackSource.padecimiento_actual),
+      diagnostico: toStr(fallbackSource.diagnostico),
+      tratamiento: toStr(fallbackSource.tratamiento),
+      notas: toStr(fallbackSource.notas),
+      interrogatorio: mapSistemasFromSource(fallbackSource),
+    };
+    const hasData =
+      ['fecha_consulta', 'recordatorio', 'padecimiento_actual', 'diagnostico', 'tratamiento', 'notas']
+        .some((key) => present(fallback[key])) || present(fallback.interrogatorio);
+    if (hasData) consultas.push(fallback);
+  }
+
+  return { consultas, pronostico };
 };
 
 const Row = ({ icon, label, value }) => {
@@ -37,105 +242,26 @@ const Row = ({ icon, label, value }) => {
   );
 };
 
-// Oculta cualquier id_* excepto id_perfil (que solo se muestra en Datos Personales)
-const notSecondaryId = (key) => !(key.startsWith('id_') && key !== 'id_perfil');
-
-// Etiquetas legibles y fallback
-const LABELS = {
-  // Perfil
-  id_perfil: 'ID de perfil',
-  nombre: 'Nombre',
-  genero: 'Género',
-  fecha_nacimiento: 'Fecha de nacimiento',
-  telefono_movil: 'Teléfono',
-  correo_electronico: 'Correo',
-  residencia: 'Residencia',
-  ocupacion: 'Ocupación',
-  escolaridad: 'Escolaridad',
-  estado_civil: 'Estado civil',
-  tipo_sangre: 'Tipo de sangre',
-  referido_por: 'Referido por',
-  creado: 'Creado',
-  actualizado: 'Actualizado',
-
-  // Antecedentes personales (1:1)
-  bebidas_por_dia: 'Bebidas por día',
-  tiempo_activo_alc: 'Tiempo activo alcohol',
-  cigarrillos_por_dia: 'Cigarrillos por día',
-  tiempo_activo_tab: 'Tiempo activo tabaco',
-  tipo_toxicomania: 'Tipo de toxicomanía',
-  tiempo_activo_tox: 'Tiempo activo toxicomanía',
-  calidad: 'Calidad del sueño',
-  descripcion: 'Descripción',
-  hay_cambios: '¿Hay cambios?',
-  cambio_tipo: 'Tipo de cambio',
-  cambio_causa: 'Causa del cambio',
-  cambio_tiempo: 'Tiempo del cambio',
-
-  // Familiares / Patológicos
-  antecedente: 'Antecedente',
-  nombre_familiar: 'Nombre',
-
-  // Padecimiento/interrogatorio
-  padecimiento_actual: 'Padecimiento actual',
-  sintomas_generales: 'Síntomas generales',
-  endocrino: 'Endocrino',
-  organos_sentidos: 'Órganos de los sentidos',
-  gastrointestinal: 'Gastrointestinal',
-  cardiopulmonar: 'Cardiopulmonar',
-  genitourinario: 'Genitourinario',
-  genital_femenino: 'Genital femenino',
-  sexualidad: 'Sexualidad',
-  dermatologico: 'Dermatológico',
-  neurologico: 'Neurológico',
-  hematologico: 'Hematológico',
-  reumatologico: 'Reumatológico',
-  psiquiatrico: 'Psiquiátrico',
-  medicamentos: 'Medicamentos',
-
-  // Exploración física
-  peso_actual: 'Peso actual (kg)',
-  peso_anterior: 'Peso anterior (kg)',
-  peso_deseado: 'Peso deseado (kg)',
-  peso_ideal: 'Peso ideal (kg)',
-  talla_cm: 'Talla (cm)',
-  imc: 'IMC',
-  rtg: 'RTG',
-  ta_mmhg: 'TA (mmHg)',
-  pulso: 'Pulso',
-  frecuencia_cardiaca: 'Frecuencia cardiaca',
-  frecuencia_respiratoria: 'Frecuencia respiratoria',
-  temperatura_c: 'Temperatura (°C)',
-  cadera_cm: 'Cadera (cm)',
-  cintura_cm: 'Cintura (cm)',
-  cabeza: 'Cabeza',
-  cuello: 'Cuello',
-  torax: 'Tórax',
-  abdomen: 'Abdomen',
-  genitales: 'Genitales',
-  extremidades: 'Extremidades',
+Row.propTypes = {
+  icon: PropTypes.node,
+  label: PropTypes.string.isRequired,
+  value: PropTypes.node,
 };
-const prettify = (key) => key.replace(/_/g, ' ').replace(/^\w/, (c) => c.toUpperCase());
-const labelFor = (key) => LABELS[key] || prettify(key);
 
 export default function ProfileInformation({ data, onEditProfile, onDeleteProfile }) {
   if (!data || data.ok !== true) return null;
 
-  // Datos Personales (id_perfil + campos raíz en orden)
   const personalOrder = [
     'id_perfil', 'nombre', 'genero', 'fecha_nacimiento', 'telefono_movil', 'correo_electronico',
     'residencia', 'ocupacion', 'escolaridad', 'estado_civil', 'tipo_sangre', 'referido_por',
-    'creado', 'actualizado'
+    'creado', 'actualizado',
   ];
-  // Helpers para fechas: usamos el valor máximo entre todas las secciones
-  const getDateStr = (v) => {
-    if (!v) return null;
-    if (typeof v === 'string') {
-      const s = v.slice(0, 10);
-      return /\d{4}-\d{2}-\d{2}/.test(s) ? s : null;
-    }
-    return null;
+
+  const getDateStr = (value) => {
+    const str = formatDate(value);
+    return str || null;
   };
+
   const computeMaxDates = () => {
     let creadoMax = getDateStr(data.creado) || null;
     let actualizadoMax = getDateStr(data.actualizado) || null;
@@ -153,7 +279,9 @@ export default function ProfileInformation({ data, onEditProfile, onDeleteProfil
       data.diagnostico_tratamiento,
       data.exploracion_fisica,
       data.padecimiento_actual_interrogatorio,
+      data.consultas,
     ];
+
     for (const arr of arrays) {
       if (!Array.isArray(arr)) continue;
       for (const it of arr) {
@@ -170,95 +298,139 @@ export default function ProfileInformation({ data, onEditProfile, onDeleteProfil
     }
     return { creadoMax, actualizadoMax };
   };
+
   const { creadoMax, actualizadoMax } = computeMaxDates();
   const personalData = { ...data, creado: creadoMax || data.creado, actualizado: actualizadoMax || data.actualizado };
-  const iconFor = (k) => {
-    switch (k) {
-      case 'id_perfil': return <FiLayers />;
-      case 'nombre': return <FiHome />;
+
+  const iconFor = (key) => {
+    switch (key) {
+      case 'id_perfil':
       case 'genero':
       case 'escolaridad':
       case 'estado_civil':
       case 'tipo_sangre':
-      case 'referido_por': return <FiLayers />;
+      case 'referido_por':
+        return <FiLayers />;
+      case 'nombre':
+      case 'residencia':
+        return <FiHome />;
       case 'fecha_nacimiento':
       case 'creado':
-      case 'actualizado': return <FiCalendar />;
-      case 'telefono_movil': return <FiPhone />;
-      case 'correo_electronico': return <FiMail />;
-      case 'residencia': return <FiHome />;
-      case 'ocupacion': return <FiBriefcase />;
-      default: return <FiLayers />;
+      case 'actualizado':
+        return <FiCalendar />;
+      case 'telefono_movil':
+        return <FiPhone />;
+      case 'correo_electronico':
+        return <FiMail />;
+      case 'ocupacion':
+        return <FiBriefcase />;
+      default:
+        return <FiLayers />;
     }
   };
+
+  const labelFor = (key) => {
+    switch (key) {
+      case 'id_perfil': return 'ID de perfil:';
+      case 'nombre': return 'Nombre:';
+      case 'genero': return 'Género:';
+      case 'fecha_nacimiento': return 'Fecha de nacimiento:';
+      case 'telefono_movil': return 'Teléfono:';
+      case 'correo_electronico': return 'Correo:';
+      case 'residencia': return 'Residencia:';
+      case 'ocupacion': return 'Ocupación:';
+      case 'escolaridad': return 'Escolaridad:';
+      case 'estado_civil': return 'Estado civil:';
+      case 'tipo_sangre': return 'Tipo de sangre:';
+      case 'referido_por': return 'Referido por:';
+      case 'creado': return 'Creado:';
+      case 'actualizado': return 'Actualizado:';
+      default: return `${key.replace(/_/g, ' ')}:`;
+    }
+  };
+
   const personalRows = personalOrder
-    .filter((k) => present(personalData[k]))
-    .map((k) => (
-      <Row key={k} icon={iconFor(k)} label={`${labelFor(k)}:`} value={personalData[k]} />
+    .filter((key) => present(personalData[key]))
+    .map((key) => (
+      <Row key={key} icon={iconFor(key)} label={labelFor(key)} value={personalData[key]} />
     ));
-  const showPersonal = personalRows.length > 0;
 
-  // 1:1: Antecedentes Personales
-  let apBlock = null;
-  if (data.antecedentes_personales && typeof data.antecedentes_personales === 'object') {
-    const entries = Object.entries(data.antecedentes_personales)
-      .filter(([k, v]) => !k.startsWith('id_') && k !== 'creado' && k !== 'actualizado' && present(v));
-    if (entries.length > 0) {
-      apBlock = (
-        <Section>
-          <h3>Antecedentes Personales</h3>
-          <TwoColumnRow>
-            {entries.map(([k, v]) => (
-              <FieldRow key={`ap_${k}`}>
-                <Label><FiLayers /> {labelFor(k)}:</Label>
-                <Value>{v}</Value>
-              </FieldRow>
-            ))}
-          </TwoColumnRow>
-        </Section>
-      );
-    }
-  }
+  const antecedentesFamiliares = toArr(data.antecedentes_familiares)
+    .map((item) => ({
+      nombre: toStr(item?.nombre),
+      descripcion: toStr(item?.descripcion),
+    }))
+    .filter((item) => present(item.nombre) || present(item.descripcion));
 
-  // 1:N helper con agrupación por "Registro N"
-  const renderArrayBlock = (arr, prefix, heading) => {
-    if (!Array.isArray(arr) || arr.length === 0) return null;
-    const groups = arr.map((item, idx) => {
-      const rows = Object.entries(item || {})
-        .filter(([k, v]) => !k.startsWith('id_') && k !== 'creado' && k !== 'actualizado' && present(v))
-        .map(([k, v]) => (
-          <FieldRow key={`${prefix}_${idx}_${k}`}>
-            <Label><FiLayers /> {labelFor(k)}:</Label>
-            <Value>{v}</Value>
-          </FieldRow>
-        ));
-      if (rows.length === 0) return null;
-      return (
-        <div key={`${prefix}_${idx}`}>
-          <TwoColumnRow>
-            {rows}
-          </TwoColumnRow>
-        </div>
-      );
-    }).filter(Boolean);
-    if (groups.length === 0) return null;
-    return (
-      <Section>
-        <h3>{heading}</h3>
-        {groups}
-      </Section>
-    );
-  };
+  const antecedentesPersonales = data.antecedentes_personales || {};
+  const apGenerales = [
+    { label: 'Calidad del sueño:', value: antecedentesPersonales.calidad },
+    { label: 'Descripción:', value: antecedentesPersonales.descripcion },
+    { label: '¿Hay cambios?:', value: antecedentesPersonales.hay_cambios },
+    { label: 'Tipo de cambio:', value: antecedentesPersonales.cambio_tipo },
+    { label: 'Causa del cambio:', value: antecedentesPersonales.cambio_causa },
+    { label: 'Tiempo del cambio:', value: antecedentesPersonales.cambio_tiempo },
+  ].filter((row) => present(row.value));
+  const apHabitos = buildHabitos(antecedentesPersonales);
 
-  const afBlock  = renderArrayBlock(data.antecedentes_familiares, 'af', 'Antecedentes Familiares');
-  const appBlock = renderArrayBlock(data.antecedentes_personales_patologicos, 'app', 'Antecedentes Personales Patológicos');
-  const paiBlock = renderArrayBlock(data.padecimiento_actual_interrogatorio, 'pai', 'Padecimiento Actual Interrogatorio');
-  const efBlock  = renderArrayBlock(data.exploracion_fisica, 'ef', 'Exploración Física');
-  const dtBlock  = renderArrayBlock(data.diagnostico_tratamiento, 'dt', 'Diagnóstico y Tratamiento');
+  const ginecoSource = Array.isArray(data.gineco_obstetricos)
+    ? data.gineco_obstetricos[0] || {}
+    : data.gineco_obstetricos || {};
+
+  const ginecoRows = [
+    { label: 'Edad de menarca:', value: ginecoSource.edad_primera_menstruacion },
+    { label: 'Ciclo / días:', value: ginecoSource.ciclo_dias },
+    { label: 'Cantidad:', value: ginecoSource.cantidad },
+    { label: 'Dolor:', value: ginecoSource.dolor },
+    { label: 'Fecha de última menstruación:', value: formatDate(ginecoSource.fecha_ultima_menstruacion) },
+    { label: 'Vida sexual activa:', value: ginecoSource.vida_sexual_activa },
+    { label: 'Anticoncepción:', value: ginecoSource.anticoncepcion },
+    { label: 'Tipo de anticonceptivo:', value: ginecoSource.tipo_anticonceptivo },
+    { label: 'Gestas:', value: ginecoSource.gestas },
+    { label: 'Partos:', value: ginecoSource.partos },
+    { label: 'Cesáreas:', value: ginecoSource.cesareas },
+    { label: 'Abortos:', value: ginecoSource.abortos },
+    { label: 'Fecha del último parto:', value: formatDate(ginecoSource.fecha_ultimo_parto) },
+    { label: 'Fecha de menopausia:', value: formatDate(ginecoSource.fecha_menopausia) },
+  ].filter((row) => present(row.value));
+
+  const patologicos = toArr(data.antecedentes_personales_patologicos)
+    .map((item, idx) => ({
+      id: item?.id || `app-${idx}`,
+      antecedente: toStr(item?.antecedente),
+      descripcion: toStr(item?.descripcion),
+    }))
+    .filter((item) => present(item.antecedente) || present(item.descripcion));
+
+  const { consultas, pronostico } = buildConsultas(data);
+
+  const efSource = Array.isArray(data.exploracion_fisica)
+    ? data.exploracion_fisica[0] || {}
+    : typeof data.exploracion_fisica === 'object' && data.exploracion_fisica !== null
+    ? data.exploracion_fisica
+    : {};
+
+  const efRows = [
+    { label: 'Peso actual (kg):', value: efSource.peso_actual },
+    { label: 'Peso anterior (kg):', value: efSource.peso_anterior },
+    { label: 'Peso deseado (kg):', value: efSource.peso_deseado },
+    { label: 'Peso ideal (kg):', value: efSource.peso_ideal },
+    { label: 'Talla (cm):', value: efSource.talla_cm },
+    { label: 'IMC:', value: efSource.imc },
+    { label: 'RTG:', value: efSource.rtg },
+    { label: 'TA (mmHg):', value: efSource.ta_mmhg },
+    { label: 'Frecuencia cardiaca:', value: efSource.frecuencia_cardiaca },
+    { label: 'Frecuencia respiratoria:', value: efSource.frecuencia_respiratoria },
+    { label: 'Temperatura (°C):', value: efSource.temperatura_c },
+    { label: 'Cadera (cm):', value: efSource.cadera_cm },
+    { label: 'Cintura (cm):', value: efSource.cintura_cm },
+  ].filter((row) => present(row.value));
+
+  const inspeccion = mapInspectionFromSource(efSource);
 
   return (
     <>
-      {showPersonal && (
+      {personalRows.length > 0 && (
         <Section>
           <h3>Datos Personales</h3>
           <TwoColumnRow>
@@ -267,12 +439,147 @@ export default function ProfileInformation({ data, onEditProfile, onDeleteProfil
         </Section>
       )}
 
-      {afBlock}
-      {apBlock}
-      {appBlock}
-      {paiBlock}
-      {efBlock}
-      {dtBlock}
+      {antecedentesFamiliares.length > 0 && (
+        <Section>
+          <h3>Antecedentes Familiares</h3>
+          <Stack>
+            {antecedentesFamiliares.map((item, idx) => (
+              <Group key={`af-${idx}`}>
+                <GroupTitle>Registro {idx + 1}</GroupTitle>
+                <Row icon={<FiLayers />} label="Antecedente:" value={item.nombre} />
+                <Row icon={<PiNoteFill />} label="Descripción:" value={item.descripcion} />
+              </Group>
+            ))}
+          </Stack>
+        </Section>
+      )}
+
+      {(apGenerales.length > 0 || apHabitos.length > 0) && (
+        <Section>
+          <h3>Antecedentes Personales</h3>
+          {apGenerales.length > 0 && (
+            <TwoColumnRow>
+              {apGenerales.map(({ label, value }, idx) => (
+                <Row key={`ap-${idx}`} icon={<FiLayers />} label={label} value={value} />
+              ))}
+            </TwoColumnRow>
+          )}
+          {apHabitos.length > 0 && (
+            <>
+              <h4>Hábitos</h4>
+              <Stack>
+                {apHabitos.map((habito, idx) => (
+                  <Group key={`habito-${idx}`}>
+                    <GroupTitle>{habito.titulo}</GroupTitle>
+                    {habito.rows.map(({ label, value }, rowIdx) => (
+                      <Row
+                        key={`habito-${idx}-${rowIdx}`}
+                        icon={<FiLayers />}
+                        label={label}
+                        value={value}
+                      />
+                    ))}
+                  </Group>
+                ))}
+              </Stack>
+            </>
+          )}
+        </Section>
+      )}
+
+      {ginecoRows.length > 0 && (
+        <Section>
+          <h3>Antecedentes Gineco-Obstétricos</h3>
+          <TwoColumnRow>
+            {ginecoRows.map(({ label, value }, idx) => (
+              <Row key={`gineco-${idx}`} icon={<FiLayers />} label={label} value={value} />
+            ))}
+          </TwoColumnRow>
+        </Section>
+      )}
+
+      {patologicos.length > 0 && (
+        <Section>
+          <h3>Antecedentes Personales Patológicos</h3>
+          <Stack>
+            {patologicos.map((item, idx) => (
+              <Group key={item.id || `pat-${idx}`}>
+                <GroupTitle>Registro {idx + 1}</GroupTitle>
+                <Row icon={<FiLayers />} label="Antecedente:" value={item.antecedente} />
+                <Row icon={<PiNoteFill />} label="Descripción:" value={item.descripcion} />
+              </Group>
+            ))}
+          </Stack>
+        </Section>
+      )}
+
+      {consultas.length > 0 && (
+        <Section>
+          <h3>Consultas</h3>
+          <Stack>
+            {consultas.map((consulta, idx) => (
+              <Group key={consulta.id || `consulta-${idx}`}>
+                <GroupTitle>
+                  Consulta {idx + 1}{present(consulta.fecha_consulta) ? ` · ${consulta.fecha_consulta}` : ''}
+                </GroupTitle>
+                <Row icon={<FiCalendar />} label="Fecha de consulta:" value={consulta.fecha_consulta} />
+                <Row icon={<FiCalendar />} label="Recordatorio:" value={consulta.recordatorio} />
+                <Row icon={<PiNoteFill />} label="Padecimiento actual:" value={consulta.padecimiento_actual} />
+                <Row icon={<PiNoteFill />} label="Diagnóstico:" value={consulta.diagnostico} />
+                <Row icon={<PiNoteFill />} label="Tratamiento:" value={consulta.tratamiento} />
+                <Row icon={<PiNoteFill />} label="Notas:" value={consulta.notas} />
+                {consulta.interrogatorio.length > 0 && (
+                  <>
+                    <h5>Interrogatorio por aparatos y sistemas</h5>
+                    {consulta.interrogatorio.map((item, interrogatorioIdx) => (
+                      <Row
+                        key={`${consulta.id}-interrogatorio-${interrogatorioIdx}`}
+                        icon={<FiLayers />}
+                        label={`${item.nombre}:`}
+                        value={item.descripcion}
+                      />
+                    ))}
+                  </>
+                )}
+              </Group>
+            ))}
+          </Stack>
+          {present(pronostico) && (
+            <Stack>
+              <Group>
+                <GroupTitle>Pronóstico</GroupTitle>
+                <Row icon={<PiNoteFill />} label="Pronóstico general:" value={pronostico} />
+              </Group>
+            </Stack>
+          )}
+        </Section>
+      )}
+
+      {(efRows.length > 0 || inspeccion.length > 0) && (
+        <Section>
+          <h3>Exploración Física</h3>
+          {efRows.length > 0 && (
+            <TwoColumnRow>
+              {efRows.map(({ label, value }, idx) => (
+                <Row key={`ef-${idx}`} icon={<FiLayers />} label={label} value={value} />
+              ))}
+            </TwoColumnRow>
+          )}
+          {inspeccion.length > 0 && (
+            <>
+              <h4>Inspección general</h4>
+              <Stack>
+                {inspeccion.map((item, idx) => (
+                  <Group key={`ins-${idx}`}>
+                    <GroupTitle>{item.nombre}</GroupTitle>
+                    <Row icon={<PiNoteFill />} label="Descripción:" value={item.descripcion} />
+                  </Group>
+                ))}
+              </Stack>
+            </>
+          )}
+        </Section>
+      )}
 
       <Section>
         <Actions>

--- a/frontend/src/components/ProfileInformation.styles.jsx
+++ b/frontend/src/components/ProfileInformation.styles.jsx
@@ -5,12 +5,35 @@ import { Palette } from '../helpers/theme.js';
 export const Section = styled.section`
   background: ${Palette.background};
   border: 1px solid ${Palette.border};
-  
+
   padding: 28px 28px;
   h3{
     font-size: 1.9rem;
-    color: ${Palette.title}; 
+    color: ${Palette.title};
   }
+`;
+
+export const Stack = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  margin-top: 18px;
+`;
+
+export const Group = styled.div`
+  border: 1px solid ${Palette.border};
+  border-radius: 12px;
+  padding: 18px;
+  background: ${Palette.accent};
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+export const GroupTitle = styled.h4`
+  margin: 0;
+  color: ${Palette.secondary};
+  font-size: 1.1rem;
 `;
 
 export const TwoRow = styled.div`


### PR DESCRIPTION
## Summary
- reescribí el componente `ProfileInformation` para mapear todos los datos devueltos por el backend, incluyendo las consultas históricas y secciones auxiliares
- añadí nuevos estilos reutilizables para agrupar filas y subsecciones dentro de la ficha de perfil

## Testing
- `npm run lint` *(falla por advertencias y errores previos en archivos ajenos a los modificados)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e3077c008324afdcf1cdc18da574