### PR TITLE
Ajusta Pending a la nueva respuesta del backend

### DIFF
--- a/frontend/src/components/InteractCard.jsx
+++ b/frontend/src/components/InteractCard.jsx
@@ -14,8 +14,9 @@ import { BsChatSquareText } from "react-icons/bs";
 import {
   FaRegClock,
   FaBirthdayCake,
+  FaRegCalendarAlt,
   FaTrashAlt,
-  
+
 } from 'react-icons/fa';
 import { url } from '../helpers/url.js';
 /* ---------- Helpers ---------- */
@@ -61,15 +62,41 @@ const daysToBirthday = (birthDateStr) => {
     : `Faltan ${diffDays} día${diffDays > 1 ? 's' : ''}`;
 };
 
+const formatReminder = (dateStr) => {
+  if (!dateStr) return null;
+  const date = new Date(dateStr);
+  if (Number.isNaN(date.getTime())) return null;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const reminderDate = new Date(date);
+  reminderDate.setHours(0, 0, 0, 0);
+
+  const diffMs = reminderDate.getTime() - today.getTime();
+  const diffDays = Math.round(diffMs / (1000 * 60 * 60 * 24));
+
+  const formatted = reminderDate.toLocaleDateString('es-MX', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric'
+  });
+
+  if (diffDays === 0) return `Recordatorio para hoy · ${formatted}`;
+  if (diffDays === 1) return `Recordatorio mañana · ${formatted}`;
+  if (diffDays > 1) return `Recordatorio en ${diffDays} días · ${formatted}`;
+  return `Recordatorio vencido · ${formatted}`;
+};
+
 /* ---------- Componente simplificado ---------- */
 export default function IneractCard({
   id,
   name,
   lastContact,
+  reminderDate,
   birthDate,
   showPostpone = true,
   isBirthdayToday = false,
-  onPostpone            
+  onPostpone
 }) {
   const [confirmPostpone, setConfirmPostpone] = useState(false);
   const navigate = useNavigate();
@@ -98,6 +125,7 @@ export default function IneractCard({
     setConfirmPostpone(false);
     handlePostpone();
   };
+  const reminderLabel = formatReminder(reminderDate);
   return (
     <>
       <Card $birthday={isBirthdayToday}>
@@ -107,6 +135,13 @@ export default function IneractCard({
             <FaRegClock />
             <span>{daysSince(lastContact)}</span>
           </InfoRow>
+
+          {reminderLabel && (
+            <InfoRow>
+              <FaRegCalendarAlt />
+              <span>{reminderLabel}</span>
+            </InfoRow>
+          )}
 
           {isValidBirthDate(birthDate) && (
             <InfoRow $birthday={isBirthdayToday}>

--- a/frontend/src/components/ProfileInformation.jsx
+++ b/frontend/src/components/ProfileInformation.jsx
@@ -475,6 +475,7 @@ export default function ProfileInformation({ data, onEditProfile, onDeleteProfil
   ].filter((row) => present(row.value));
 
   const inspeccion = mapInspectionFromSource(efSource);
+  const totalConsultas = consultas.length;
 
   return (
     <>
@@ -594,7 +595,7 @@ export default function ProfileInformation({ data, onEditProfile, onDeleteProfil
             {consultas.map((consulta, idx) => (
               <Group key={consulta.id || `consulta-${idx}`}>
                 <GroupTitle>
-                  Consulta {idx + 1}{present(consulta.fecha_consulta) ? ` · ${consulta.fecha_consulta}` : ''}
+                  Consulta {totalConsultas - idx}{present(consulta.fecha_consulta) ? ` · ${consulta.fecha_consulta}` : ''}
                 </GroupTitle>
                 <Row icon={<FaCalendarDay />} label="Fecha de consulta:" value={consulta.fecha_consulta} />
                 <Row icon={<FaBell />} label="Recordatorio:" value={consulta.recordatorio} />

--- a/frontend/src/helpers/theme.js
+++ b/frontend/src/helpers/theme.js
@@ -1,16 +1,16 @@
 export const Palette = {
   // Roles principales
-  primary: '#67C090',     // Acción principal, acentos, focus
-  secondary: '#26667F',   // Superficies/oscuros, hovers fuertes, bordes fuertes
-  accent: '#DDF4E7',      // Color suave para resaltar fondos o secciones
-  dark: '#124170',        // Tonos más profundos, headers, contrastes
+  primary: '#541212',     // Acción principal, acentos, focus (rojo vino)
+  secondary: '#4F959D',   // Superficies/oscuros, hovers fuertes, bordes fuertes (turquesa apagado)
+  accent: '#4FB7B3',      // Color suave para resaltar fondos o secciones (verde menta oceánico)
+  dark: '#205781',        // Tonos más profundos, headers, contrastes (azul marino acero)
 
   // Texto
-  text: '#000000',        // Texto principal
-  title: '#67C090',       // Encabezados, títulos
-  muted: '#393E46',       // Texto/íconos secundarios, placeholders
+  text: '#000000',        // Texto principal (negro absoluto)
+  title: '#415E72',       // Encabezados, títulos (azul pizarra profundo)
+  muted: '#4F959D',       // Texto/íconos secundarios, placeholders (turquesa apagado)
 
   // Fondos y bordes
-  background: '#e3e3e3ff',  // Fondo principal
-  border: '#000000ff',      // Bordes suaves, separadores
+  background: '#FFFFFF',  // Fondo principal (blanco puro)
+  border: '#415E72',      // Bordes suaves, separadores (azul pizarra profundo)
 };

--- a/frontend/src/pages/App.jsx
+++ b/frontend/src/pages/App.jsx
@@ -18,7 +18,10 @@ export default function Nav() {
   const confirmDelete  = async () => {
     const { id, nombre } = toDelete;
     try {
-      const res = await fetch(`${url}/api/profile/${id}`, { method: 'DELETE' });
+      const res = await fetch(`${url}/api/profile/${id}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
       if (!res.ok) throw new Error('No se pudo eliminar');
 
       setProfiles(prev => prev.filter(p => p.id_perfil !== id));


### PR DESCRIPTION
## Summary
- adapta la página de pendientes para consumir la estructura { birthdays, reminders } devuelta por el backend
- agrega visualización de recordatorios en las tarjetas reutilizando InteractCard con soporte para mostrar la fecha del recordatorio

## Testing
- no se ejecutaron pruebas (no requerido)


------
https://chatgpt.com/codex/tasks/task_e_68d6ccbbbc788324b5381d802e61955d