### PR TITLE
Clear consultation reminder when postponing

### DIFF
--- a/backend/src/controllers/user.js
+++ b/backend/src/controllers/user.js
@@ -19,20 +19,21 @@ const SISTEMA_FIELD_CONFIGS = [
   { key: 'medicamentos', desc: 'medicamentos_desc', estado: 'medicamentos_estado' },
 ];
 
-// POST /postpone { id }
+// POST /postpone { id_consulta }
 const postpone = async (req, res) => {
   try {
-    const { id } = req.body;
-    if (!id || isNaN(Number(id))) {
-      return res.status(400).json({ error: 'ID inválido' });
+    const { id_consulta } = req.body;
+    const consultaId = Number(id_consulta);
+    if (!Number.isInteger(consultaId) || consultaId <= 0) {
+      return res.status(400).json({ error: 'ID de consulta inválido' });
     }
 
-    const result = await bd.postponeContactDate(id);
+    const result = await bd.postponeContactDate(consultaId);
     if (result.affectedRows === 0) {
-      return res.status(404).json({ error: 'Cliente no encontrado' });
+      return res.status(404).json({ error: 'Consulta no encontrada' });
     }
 
-    res.status(200).json({ msg: `Contacto para ID ${id} pospuesto 45 días` });
+    res.status(200).json({ msg: `Recordatorio eliminado para la consulta ${consultaId}` });
   } catch (err) {
     console.error('Error al posponer contacto:', err);
     res.status(500).json({ error: err.message });

--- a/backend/src/models/profile.js
+++ b/backend/src/models/profile.js
@@ -414,11 +414,11 @@ async function updateUltimaFechaContacto(id, fecha) {
   return result;
 }
 
-// Suma "days" a la ultima_fecha_contacto de un cliente
-async function postponeContactDate(id, days = 45) {
+// Elimina el recordatorio asociado a una consulta específica
+async function postponeContactDate(id_consulta) {
   const [result] = await db.query(
-    'UPDATE clientes SET ultima_fecha_contacto = DATE_ADD(ultima_fecha_contacto, INTERVAL ? DAY) WHERE id_cliente = ?',
-    [days, id]
+    'UPDATE consultas SET recordatorio = NULL WHERE id_consulta = ?',
+    [id_consulta]
   );
   return result;
 }

--- a/frontend/src/components/InteractCard.jsx
+++ b/frontend/src/components/InteractCard.jsx
@@ -90,6 +90,7 @@ const formatReminder = (dateStr) => {
 /* ---------- Componente simplificado ---------- */
 export default function IneractCard({
   id,
+  consultaId,
   name,
   lastContact,
   ultima_fecha_contacto,
@@ -105,13 +106,14 @@ export default function IneractCard({
   const handleView = () => {
     navigate(`/profile/${id}`);
   };
+  const effectiveConsultaId = consultaId ?? id;
   const handlePostpone = async () => {
     try {
       const res = await fetch(`${url}/api/postpone`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ id })
+        body: JSON.stringify({ id_consulta: effectiveConsultaId })
       });
       onPostpone?.(id);
       if (!res.ok) throw new Error('Error al posponer');

--- a/frontend/src/pages/Pending.jsx
+++ b/frontend/src/pages/Pending.jsx
@@ -99,6 +99,7 @@ function Pending() {
                 <InteractCard
                   key={item.consultaId ?? item.id}
                   id={item.id}
+                  consultaId={item.consultaId}
                   name={item.name}
                   lastContact={item.lastContact}
                   reminderDate={item.reminderDate}


### PR DESCRIPTION
## Summary
- update the postpone controller to consume `id_consulta` and return consulta-specific responses
- change the profile model so postponing clears the `recordatorio` for the targeted consulta

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d72998c2d4832482cf561f4e976619