### PR TITLE
Allow MessageGenerator summaries when WhatsApp service is unavailable

### DIFF
--- a/frontend/src/components/MessageGenerator.styles.jsx
+++ b/frontend/src/components/MessageGenerator.styles.jsx
@@ -44,7 +44,8 @@ export const ModeSwitch = styled.label`
   display: inline-block;
   width: 52px;
   height: 28px;
-  cursor: pointer;
+  cursor: ${({ $disabled }) => ($disabled ? 'not-allowed' : 'pointer')};
+  opacity: ${({ $disabled }) => ($disabled ? 0.6 : 1)};
 `;
 
 export const ModeCheckbox = styled.input`
@@ -52,11 +53,19 @@ export const ModeCheckbox = styled.input`
   width: 0;
   height: 0;
 
+  &:disabled {
+    cursor: not-allowed;
+  }
+
   &:checked + span {
     background: ${Palette.primary};
   }
   &:checked + span:before {
     transform: translateX(24px);
+  }
+
+  &:disabled + span {
+    filter: grayscale(0.35);
   }
 `;
 


### PR DESCRIPTION
## Summary
- keep MessageGenerator available for AI summaries and usage limits even when the WhatsApp service is not ready, while disabling message and image actions and surfacing the service status
- update the mode switch styling so the disabled state is clearly reflected when messaging is unavailable

## Testing
- npm --prefix frontend run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d8418cd0988324838508f2a4bc3c74