### PR TITLE
Change backend default port to 5003

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -45,7 +45,7 @@ app.get(['/', '/add', '/pending', '/login', '/link', '/profile/:id', '/calendar'
 app.get(['/contracts'], (req, res) => {
   res.sendFile(indexFile);
 });
-const PORT = process.env.PORT || 5000;
+const PORT = process.env.PORT || 5003;
 app.listen(PORT, () => console.log(`Backend corriendo en puerto ${PORT}`));
 
 // Agenda la depuración mensual de citas (día 1 a las 03:00 America/Mexico_City)


### PR DESCRIPTION
## Summary
- update the backend index to listen on port 5003 by default

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9ee3819988324849ab40e7088dcf3